### PR TITLE
Update jQuery version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To create a font selector simply run the plugin on a standard html input element
 
 ### How to use
 
-        $('input.fonts').fontselect();
+    $('input.fonts').fontselect();
 
 ### Options
 
@@ -22,25 +22,25 @@ Fontselect has one argument, an options object that you might want to customise:
 * placeholder: text to use when no font is selected yet
 * lookahead: a number of fonts to try and preload ahead in the select box
 
-        $('input.fonts').fontselect({
-          style: 'font-select',
-          placeholder: 'Select a font',
-          lookahead: 2
-        });
-           
+    $('input.fonts').fontselect({
+      style: 'font-select',
+      placeholder: 'Select a font',
+      lookahead: 2
+    });
+
 ### Events
 
 Fontselect triggers the change event on the original element when a font is selected. 
 An example is included to show how this could be used to update the font on the current page.
 
-        $('input.fonts').fontselect().change(function(){
-        
-          // replace + signs with spaces for css
-          var font = $(this).val().replace(/\+/g, ' ');
-          
-          // log font name
-          console.log(font);
-        });
+    $('input.fonts').fontselect().change(function(){
+    
+      // replace + signs with spaces for css
+      var font = $(this).val().replace(/\+/g, ' ');
+      
+      // log font name
+      console.log(font);
+    });
 
 
 

--- a/examples/change.html
+++ b/examples/change.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>Jquery Fontselect Example</title>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.6/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
     <link rel="stylesheet" type="text/css" href="../styles/fontselect-alternate.css" />
     <script src="../jquery.fontselect.js"></script>
     <script>

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>Jquery Fontselect Example</title>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.6/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
     <link rel="stylesheet" type="text/css" href="styles/fontselect-default.css" />
     <script src="jquery.fontselect.js"></script>
     <script>

--- a/jquery.fontselect.js
+++ b/jquery.fontselect.js
@@ -259,7 +259,7 @@
         var self = this;
         // Close dropdown automatically on clicks outside dropdown
         $(document).click(function(event){
-          if(self.active && !$(event.target).parents('#fontSelect-'+ self.$original.context.id).length){
+          if(self.active && !$(event.target).parents('#fontSelect-'+ self.$original.id).length){
             self.toggleDrop();
           }
         });
@@ -330,7 +330,7 @@
       Fontselect.prototype.setupHtml = function(){
       
         this.$original.empty().hide();
-        this.$element = $('<div>', {'id': 'fontSelect-'+this.$original.context.id, 'class': this.options.style});
+        this.$element = $('<div>', {'id': 'fontSelect-'+this.$original.id, 'class': this.options.style});
         this.$arrow = $('<div><b></b></div>');
         this.$select = $('<a><span>'+ this.options.placeholder +'</span></a>');
         this.$drop = $('<div>', {'class': 'fs-drop'});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fontselect-jquery-plugin",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "A jQuery font selector for Google Web Fonts",
   "main": "jquery.fontselect.js",
   "directories": {


### PR DESCRIPTION
Fixes This issue: https://github.com/seanvm/fontselect-jquery-plugin/issues/1

* `.context()` is completely removed as of jQuery 3+. 
* This PR removes the unnecessary use of `.context()` and sets the default jQuery version in the examples to be `3.3.1`.